### PR TITLE
Allow passing custom className to FormInput

### DIFF
--- a/src/formInput.js
+++ b/src/formInput.js
@@ -4,14 +4,14 @@ import classnames from 'classnames'
 import FormField from './formField'
 import FormError from './formError'
 
-export default function FormInput ({ field, showErrors = true, errorBefore, isForm, children }) {
+export default function FormInput ({ field, showErrors = true, errorBefore, isForm, className, children }) {
   return (
     <FormField field={field}>
       {({ ...api }) => {
         const showAnyErrors = showErrors && (isForm ? api.getTouched() === true : true)
         const classes = classnames('FormInput', {
           '-hasError': !errorBefore && showAnyErrors && api.getTouched() && api.getError()
-        })
+        }, className)
 
         return (
           <div className={classes}>


### PR DESCRIPTION
Sometimes, I'd like `FormInput` to be an inline DOM element (by default, it uses `div` tag, so it's a block element) - I can add CSS targeting `.FormInput` class, but I think allowing users to customize the class name of `FormInput` seems like a more flexible solution.