### PR TITLE
Resolves #67 - Add strict value support for select options

### DIFF
--- a/src/formInputs/select.js
+++ b/src/formInputs/select.js
@@ -37,8 +37,8 @@ export default function FormInputSelect ({
             {resolvedOptions.map((option, i) => {
               return (
                 <option
-                  key={i}
-                  value={i}
+                  key={option.value || i}
+                  value={option.value || i}
                   disabled={option.disabled}
                 >
                   {option.label}


### PR DESCRIPTION
Select options now prefer to use the provided value for both the key and value attributes. If no value is given, defaults to ordinal position within the list.