### PR TITLE
Check the input values on componentDidMount

### DIFF
--- a/src/components/form-fields/Text.js
+++ b/src/components/form-fields/Text.js
@@ -5,12 +5,32 @@ import React, { Component } from 'react'
 import withField from '../withField'
 
 class TextWrapper extends Component {
+  setElem = elem => {
+    const { ref } = this.props
+    this.elem = elem
+    if (ref) {
+      ref(elem)
+    }
+  }
+  elem = null
+
+  componentDidMount () {
+    const { value, fieldApi: { setTouched, setValue } } = this.props
+    const expected = !value && value !== 0 ? '' : String(value)
+    const actual = this.elem.value
+    if (expected !== actual) {
+      setTouched()
+      setValue(actual)
+    }
+  }
+
   render () {
     const { fieldApi: { value, setValue, setTouched }, onChange, onBlur, ...rest } = this.props
 
     return (
       <input
         {...rest}
+        ref={this.setElem}
         value={!value && value !== 0 ? '' : value}
         onChange={e => {
           setValue(e.target.value)


### PR DESCRIPTION
This way, react-form will correctly get form changes that happened
*before* react is initialized via `ReactDOM.hydrate`

Fixes #314 

I would primarily like to get some feedback on my approach:
* I created a test that manually uses jsdom, because enzyme does not yet support tests of reacts `hydrate` api. That makes things a little less nice.
* If you like the `ref`/`componentDidMoint` approach, I can also extract that into a different file and also add it to the other available components. So far, it was just a PoC.