### PR TITLE
Add TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepare": "yarn build",
     "release": "yarn publish",
     "releaseNext": "yarn publish --tag next",
-    "format": "prettier {src,src/**}/*.{md,js,jsx,tsx} --write"
+    "format": "prettier {src,src/**}/*.{md,js,jsx,tsx,ts} --write"
   },
   "peerDependencies": {
     "prop-types": "^15.5.4",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,7 +10,7 @@ declare module 'react-form' {
     SetStateAction,
   } from 'react'
 
-  type Debounce = <T>(fn: (...args: any[]) => T, wait: number) => Promise<T>
+  type Debounce = <T>(fn: () => T, wait: number) => Promise<T>
   type ValidatorReturn = string | false | undefined
   type OptionalPromise<T> = Promise<T> | T
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -107,7 +107,7 @@ declare module 'react-form' {
   >(): FormInstance<TValues, CustomFormMeta>
 
   interface FieldMeta {
-    error: string | false
+    error: ValidationError
     isTouched: boolean
     isValidating?: boolean
   }
@@ -155,7 +155,7 @@ declare module 'react-form' {
 
   interface FieldOptions<TValue, CustomFieldMeta, TFormValues, CustomFormMeta> {
     defaultValue?: TValue
-    defaultError?: string
+    defaultError?: ValidationError
     defaultIsTouched?: boolean
     defaultMeta?: FieldMeta & CustomFieldMeta
     validate?: (

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -95,7 +95,7 @@ declare module 'react-form' {
     | Partial<FieldMeta>
     | ((previousMeta: FieldMeta) => FieldMeta)
 
-  interface FieldInstance<T = any, F = any> {
+  interface FieldInstance<T = any, F = {}> {
     form: FormInstance<F>
     fieldName: string
     value: T
@@ -130,9 +130,9 @@ declare module 'react-form' {
     defaultMeta?: FieldMeta
     validate?: (
       value: T,
-      instance: FieldInstance
+      instance: FieldInstance<T>
     ) => OptionalPromise<ValidatorReturn>
-    filterValue?: <T = any>(values: T, instance: FieldInstance) => T
+    filterValue?: (value: T, instance: FieldInstance<T>) => T
     validatePristine?: boolean
   }
 
@@ -141,8 +141,7 @@ declare module 'react-form' {
     options?: FieldOptions<T>
   ): FieldInstance
 
-  interface FieldOptionProps<T = any, Form = any>
-    extends FieldOptions<T> {
+  interface FieldOptionProps<T = any, Form = any> extends FieldOptions<T> {
     onSubmit?: (value: T, instance: FormInstance<Form>) => OptionalPromise<void>
     defaultValues?: Form
     debugForm?: boolean

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -108,7 +108,7 @@ declare module 'react-form' {
         Pick<HTMLProps<HTMLInputElement>, 'onSubmit'> &
         Pick<HTMLProps<HTMLInputElement>, 'onBlur'>
     ) => {
-      value: string | string[] | number
+      value: T
       onChange: ChangeEventHandler<HTMLInputElement>
       onBlur: FocusEventHandler<HTMLInputElement>
     } & Partial<HTMLProps<HTMLInputElement>>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,18 +24,19 @@ declare module 'react-form' {
     fieldsAreValidating: boolean
     fieldsAreValid: boolean
     canSubmit: boolean
-    [k: string]: any
   }
 
-  type SetFormMeta = Partial<FormMeta> | ((previousMeta: FormMeta) => FormMeta)
+  type SetFormMeta<C> =
+    | Partial<FormMeta & C>
+    | ((previousMeta: FormMeta & C) => FormMeta & C)
 
-  interface FormInstance<T> {
+  interface FormInstance<T, C = Record<string, any>> {
     Form: ComponentType<Omit<HTMLProps<HTMLFormElement>, 'onSubmit'>>
     values: T
-    meta: FormMeta
+    meta: FormMeta & C
     formContext: FormInstance<T>
     reset: () => void
-    setMeta: (value: SetFormMeta) => void
+    setMeta: (value: SetFormMeta<C>) => void
     handleSubmit: FormEventHandler<HTMLFormElement>
     debounce: Debounce
     setValues: Dispatch<SetStateAction<T>>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,158 @@
+declare module 'react-form' {
+  import {
+    ChangeEventHandler,
+    ComponentType,
+    Dispatch,
+    FocusEventHandler,
+    FormEventHandler,
+    HTMLProps,
+    Provider,
+    SetStateAction,
+  } from 'react'
+
+  type Debounce = <T>(fn: (...args: any[]) => T, wait: number) => Promise<T>
+  type ValidatorReturn = string | false | undefined
+  type OptionalPromise<T> = Promise<T> | T
+
+  interface FormMeta {
+    error: string | any
+    isSubmitting: boolean
+    isDirty: boolean
+    isSubmitted: boolean
+    submissionAttempts: number
+    isValid: boolean
+    fieldsAreValidating: boolean
+    fieldsAreValid: boolean
+    canSubmit: boolean
+    [k: string]: any
+  }
+
+  type SetFormMeta = Partial<FormMeta> | ((previousMeta: FormMeta) => FormMeta)
+
+  interface FormInstance<T> {
+    Form: ComponentType<Omit<HTMLProps<HTMLFormElement>, 'onSubmit'>>
+    values: T
+    meta: FormMeta
+    formContext: FormInstance<T>
+    reset: () => void
+    setMeta: (value: SetFormMeta) => void
+    handleSubmit: FormEventHandler<HTMLFormElement>
+    debounce: Debounce
+    setValues: Dispatch<SetStateAction<T>>
+    runValidation: () => void
+    getFieldValue: <V = any>(fieldPath: keyof T | string) => V
+    getFieldMeta: (
+      fieldPath: keyof T | string
+    ) => { error: string | null; [k: string]: any }
+    setFieldValue: <V = any>(
+      fieldPath: keyof T | string,
+      updater: SetValue<V>,
+      options?: { isTouched: boolean }
+    ) => void
+    setFieldMeta: (fieldPath: keyof T | string, value: SetFieldMeta) => void
+    pushFieldValue: <V = any>(fieldPath: keyof T | string, value: V) => void
+    insertFieldValue: <V = any>(
+      fieldPath: keyof T | string,
+      insertIndex: number,
+      value: V
+    ) => void
+    removeFieldValue: (
+      fieldPath: keyof T | string,
+      removalIndex: number
+    ) => void
+    swapFieldValues: (
+      fieldPath: keyof T | string,
+      firstIndex: number,
+      secondIndex: number
+    ) => void
+  }
+
+  interface FormOptions<T> {
+    defaultValues: T
+    onSubmit: (values: T, instance: FormInstance<T>) => OptionalPromise<void>
+    validate: (
+      values: Partial<T>,
+      instance: FormInstance<T>
+    ) => OptionalPromise<ValidatorReturn>
+    validatePristine?: boolean
+    debugForm: boolean
+  }
+
+  export function useForm<T extends {} = {}>(
+    options?: Partial<FormOptions<T>>
+  ): FormInstance<T>
+
+  export function useFormContext<T extends {} = {}>(): FormInstance<T>
+
+  interface FieldMeta {
+    error: string | false
+    isTouched: boolean
+    [k: string]: any
+  }
+
+  type SetValue<S> = S | ((prevState: S) => S)
+  type SetFieldMeta =
+    | Partial<FieldMeta>
+    | ((previousMeta: FieldMeta) => FieldMeta)
+
+  interface FieldInstance<T = any, F = any> {
+    form: FormInstance<F>
+    fieldName: string
+    value: T
+    meta: FieldMeta
+    FieldScope?: ComponentType<Provider<any>>
+    debounce: Debounce
+    runValidation: () => void
+    getInputProps: (
+      value: Partial<HTMLProps<HTMLInputElement>> &
+        Pick<HTMLProps<HTMLInputElement>, 'onSubmit'> &
+        Pick<HTMLProps<HTMLInputElement>, 'onBlur'>
+    ) => {
+      value: string | string[] | number
+      onChange: ChangeEventHandler<HTMLInputElement>
+      onBlur: FocusEventHandler<HTMLInputElement>
+    } & Partial<HTMLProps<HTMLInputElement>>
+    setValue: <V = any>(
+      updater: SetValue<V>,
+      options?: { isTouched: boolean }
+    ) => void
+    setMeta: (value: SetFieldMeta) => void
+    pushValue: <V = any>(value: V) => void
+    insertValue: <V = any>(insertIndex: number, value: V) => void
+    removeValue: (removalIndex: number) => void
+    swapValues: (firstIndex: number, secondIndex: number) => void
+  }
+
+  interface FieldOptions<T> {
+    defaultValue?: T
+    defaultError?: string
+    defaultIsTouched?: boolean
+    defaultMeta?: FieldMeta
+    validate?: (
+      value: T,
+      instance: FieldInstance
+    ) => OptionalPromise<ValidatorReturn>
+    filterValue?: <T = any>(values: T, instance: FieldInstance) => T
+    validatePristine?: boolean
+  }
+
+  export function useField<T = any>(
+    fieldPath: string,
+    options?: FieldOptions<T>
+  ): FieldInstance
+
+  interface FieldOptionProps<T = any, Form = any>
+    extends FieldOptions<T> {
+    onSubmit?: (value: T, instance: FormInstance<Form>) => OptionalPromise<void>
+    defaultValues?: Form
+    debugForm?: boolean
+  }
+
+  export function splitFormProps<P = {}, T = any>(
+    props: FieldProps<T> & P
+  ): [typeof props['field'], FieldOptionProps<T>, P]
+
+  export interface FieldProps<T = any> extends FieldOptionProps<T> {
+    field: string
+  }
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -131,7 +131,7 @@ declare module 'react-form' {
     debounce: Debounce
     runValidation: () => void
     getInputProps: (
-      value: Partial<HTMLProps<HTMLInputElement>> &
+      value?: Partial<HTMLProps<HTMLInputElement>> &
         Pick<HTMLProps<HTMLInputElement>, 'onSubmit'> &
         Pick<HTMLProps<HTMLInputElement>, 'onBlur'>
     ) => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,9 +10,9 @@ declare module 'react-form' {
     SetStateAction,
   } from 'react'
 
-  type SerializableObject = { [key: string]: Serializable }
-  interface SerializableArray extends Array<Serializable> {}
-  type Serializable =
+  export type SerializableObject = { [key: string]: Serializable }
+  export interface SerializableArray extends Array<Serializable> {}
+  export type Serializable =
     | string
     | number
     | boolean
@@ -20,12 +20,16 @@ declare module 'react-form' {
     | SerializableObject
     | SerializableArray
 
-  type Debounce = <T>(fn: () => T, wait: number) => Promise<T>
-  type ValidatorReturn = string | false | undefined
-  type OptionalPromise<T> = Promise<T> | T
-  type ValidationError = string | false | null | undefined
+  export type Debounce = <T>(fn: () => T, wait: number) => Promise<T>
+  export type FieldValidator<
+    TValue,
+    Instance = FieldInstance<TValue, {}, {}, {}>
+  > = (value: TValue, instance: Instance) => OptionalPromise<ValidatorReturn>
+  export type ValidatorReturn = string | false | undefined
+  export type OptionalPromise<T> = Promise<T> | T
+  export type ValidationError = string | false | null | undefined
 
-  interface FormMeta {
+  export interface FormMeta {
     error: ValidationError
     isSubmitting: boolean
     isDirty: boolean
@@ -37,11 +41,11 @@ declare module 'react-form' {
     canSubmit: boolean
   }
 
-  type SetFormMeta<C> =
+  export type SetFormMeta<C> =
     | Partial<FormMeta & C>
     | ((previousMeta: FormMeta & C) => FormMeta & C)
 
-  interface FormInstance<TValues, CustomFormMeta> {
+  export interface FormInstance<TValues, CustomFormMeta> {
     Form: ComponentType<Omit<HTMLProps<HTMLFormElement>, 'onSubmit'>>
     values: TValues
     meta: FormMeta & CustomFormMeta
@@ -80,7 +84,7 @@ declare module 'react-form' {
     ) => void
   }
 
-  interface FormOptions<TValues, CustomFormMeta> {
+  export interface FormOptions<TValues, CustomFormMeta> {
     defaultValues: TValues
     onSubmit: (
       values: TValues,
@@ -96,28 +100,28 @@ declare module 'react-form' {
 
   export function useForm<
     TValues extends {} = SerializableObject,
-    CustomFormMeta extends {} = Record<string, any>
+    CustomFormMeta extends {} = {}
   >(
     options?: Partial<FormOptions<TValues, CustomFormMeta>>
   ): FormInstance<TValues, CustomFormMeta>
 
   export function useFormContext<
     TValues extends {} = SerializableObject,
-    CustomFormMeta extends {} = Record<string, any>
+    CustomFormMeta extends {} = {}
   >(): FormInstance<TValues, CustomFormMeta>
 
-  interface FieldMeta {
+  export interface FieldMeta {
     error: ValidationError
     isTouched: boolean
     isValidating?: boolean
   }
 
-  type SetValue<S> = S | ((prevState: S) => S)
-  type SetFieldMeta<C> =
+  export type SetValue<S> = S | ((prevState: S) => S)
+  export type SetFieldMeta<C> =
     | Partial<FieldMeta & C>
     | ((previousMeta: FieldMeta & C) => FieldMeta & C)
 
-  interface FieldInstance<
+  export interface FieldInstance<
     TValue,
     CustomFieldMeta,
     TFormValues,
@@ -153,20 +157,20 @@ declare module 'react-form' {
     swapValues: (firstIndex: number, secondIndex: number) => void
   }
 
-  interface FieldOptions<TValue, CustomFieldMeta, TFormValues, CustomFormMeta> {
+  export interface FieldOptions<
+    TValue,
+    CustomFieldMeta,
+    TFormValues,
+    CustomFormMeta
+  > {
     defaultValue?: TValue
     defaultError?: ValidationError
     defaultIsTouched?: boolean
     defaultMeta?: FieldMeta & CustomFieldMeta
-    validate?: (
-      value: TValue,
-      instance: FieldInstance<
-        TValue,
-        CustomFieldMeta,
-        TFormValues,
-        CustomFormMeta
-      >
-    ) => OptionalPromise<ValidatorReturn>
+    validate?: FieldValidator<
+      TValue,
+      FieldInstance<TValue, CustomFieldMeta, TFormValues, CustomFormMeta>
+    >
     filterValue?: (
       value: TValue,
       instance: FieldInstance<
@@ -181,19 +185,19 @@ declare module 'react-form' {
 
   export function useField<
     TValue = Serializable,
-    CustomFieldMeta extends {} = Record<string, any>,
+    CustomFieldMeta extends {} = {},
     TFormValues extends {} = SerializableObject,
-    CustomFormMeta extends {} = Record<string, any>
+    CustomFormMeta extends {} = {}
   >(
     fieldPath: string,
     options?: FieldOptions<TValue, CustomFieldMeta, TFormValues, CustomFormMeta>
   ): FieldInstance<TValue, CustomFieldMeta, TFormValues, CustomFormMeta>
 
-  interface FieldOptionProps<
+  export interface FieldOptionProps<
     TValue = Serializable,
-    CustomFieldMeta extends {} = Record<string, any>,
+    CustomFieldMeta extends {} = {},
     TFormValues extends {} = SerializableObject,
-    CustomFormMeta extends {} = Record<string, any>
+    CustomFormMeta extends {} = {}
   > extends FieldOptions<TValue, CustomFieldMeta, TFormValues, CustomFormMeta> {
     onSubmit?: (
       value: TValue,
@@ -206,9 +210,9 @@ declare module 'react-form' {
   export function splitFormProps<
     P = {},
     TValue = Serializable,
-    CustomFieldMeta extends {} = Record<string, any>,
+    CustomFieldMeta extends {} = {},
     TFormValues extends {} = SerializableObject,
-    CustomFormMeta extends {} = Record<string, any>
+    CustomFormMeta extends {} = {}
   >(
     props: FieldProps<TValue, CustomFieldMeta, TFormValues, CustomFormMeta> & P
   ): [
@@ -219,9 +223,9 @@ declare module 'react-form' {
 
   export interface FieldProps<
     TValue = Serializable,
-    CustomFieldMeta extends {} = Record<string, any>,
+    CustomFieldMeta extends {} = {},
     TFormValues extends {} = SerializableObject,
-    CustomFormMeta extends {} = Record<string, any>
+    CustomFormMeta extends {} = {}
   >
     extends FieldOptionProps<
       TValue,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -141,7 +141,7 @@ declare module 'react-form' {
     options?: FieldOptions<T>
   ): FieldInstance
 
-  interface FieldOptionProps<T = any, Form = any> extends FieldOptions<T> {
+  interface FieldOptionProps<T = any, Form = {}> extends FieldOptions<T> {
     onSubmit?: (value: T, instance: FormInstance<Form>) => OptionalPromise<void>
     defaultValues?: Form
     debugForm?: boolean


### PR DESCRIPTION
This adds very rough initial typings for react-form. I based it off of the API docs and looking through some of the source. There are many uses of `any` throughout the types, particularly around getting and setting values and meta. I've never created a types for a library, so I'm not sure what is desired for tooling around testing, bundling, or linting the types. Some review would be much appreciated 🙂

Here's what I think needs to be worked on still

- [x] Refactor out as many uses of `any` as we can
- ~[ ] Find a type pattern for string object accessing, or can we change that to be functions to access nested data, a-la `mapStateToProps` in redux in order to be able to statically type check it?~ (I discussed this with Tanner, and don't this is going to be able to happen)
- [ ] Bundle types in dist
- [ ] Add typescript eslant plugins to lint the declarations
- [ ] Some testing or validation of the types?
- [ ] Docs and examples around the top-level functions (`useForm`, `useField`, etc.)