### PR TITLE
Add React 17 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.4",
-    "react": "^16.8.3"
+    "react": "^16.8.3 || ^17.0.0"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
This library (though officially not maintained) works fine in React 17

The reasoning for this is because NPM v7 installs peerDependencies by default. The only way to get around the conflict when using this library and React 17 is to append `--legacy-peer-deps`